### PR TITLE
Fix initializer arity deprecation in ember >2.1

### DIFF
--- a/addon/initializers/register-google.js
+++ b/addon/initializers/register-google.js
@@ -1,4 +1,6 @@
-export function initialize(container, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
+
   application.register('google:main', window.google, { instantiate: false });
   application.inject('component', 'google', 'google:main');
 }

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,14 @@
 {
   "name": "ember-place-autocomplete",
   "dependencies": {
-    "ember": "1.13.7",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.12",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-resolver": "~0.1.18",
+    "ember": "~2.2.0",
+    "ember-cli-shims": "0.0.6",
+    "ember-cli-test-loader": "0.2.1",
+    "ember-data": "~2.2.0",
+    "ember-load-initializers": "0.1.7",
+    "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
+    "loader.js": "3.4.0",
     "ember-mocha": "~0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,22 +19,22 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
-    "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.5.0",
+    "ember-cli": "1.13.13",
+    "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.1",
-    "ember-cli-ic-ajax": "0.2.1",
+    "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-release": "0.2.3",
-    "ember-cli-sri": "^1.0.3",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.12",
+    "ember-data": "~2.2.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.6",
-    "ember-cli-mocha": "0.9.3"
+    "ember-try": "0.0.8",
+    "ember-cli-mocha": "0.9.8"
   },
   "keywords": [
     "ember-addon",
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
In ember 2.1 the arity of initializers has been changed. This causes ember-place-autocomplete to trigger a deprecation warning in ember 2.1 and above.

This pull request updates the dependencies to the latest versions of ember and ember-data. It also updates all other dependencies to match the latest ember-cli dependencies according to [ember-outdated](https://github.com/dstaley/ember-outdated).

To fix the deprecation warning the backward compatible method suggested by [emberjs.com/deprecations](http://emberjs.com/deprecations/v2.x/#toc_initializer-arity) is used. The change was tested with and without the new dependencies to make sure that the addon works for version prior to 2.1 and for version 2.1 and above