### PR TITLE
Add workaround for bug where clicking auto-suggestion does not update…

### DIFF
--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -28,6 +28,8 @@ export default Ember.Component.extend({
     let actionName = this.get(callback);
     if(Ember.isPresent(actionName) && Ember.isPresent(this.get('handlerController'))){
       this.get('handlerController').send(actionName, this.get('autocomplete').get('place'));
+      // Clicking on the auto-complete result does NOT update this.value - Ember 2.4.1
+      this.set('value', Ember.$('input').val());
     }
   },
 


### PR DESCRIPTION
… value

See the bound url param below:
![change value](https://cloud.githubusercontent.com/assets/664467/13786341/177cfe28-eaa5-11e5-982f-38dbd2a7b225.gif)

I dunno if this is the proper way to fix or not, but it does work -- very open to suggestions.