### PR TITLE
Add Config options for 'exclude' and 'client'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ In order to use this addon you just have to use the component in your templates.
 
 ```
 
-You can supply your own Google API key in `config/environment.js`:
+You can supply your own Google API key or client ID in `config/environment.js`. You may also choose to exclude the Google API from the page if it is already loaded in your app:
 
 ```js
 ENV['place-autocomplete'] = {
-  key: 'AIZ...'
+  exclude: true,
+  key: 'AIZ...',
+  client: 'gme-myclientid'
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -10,10 +10,13 @@ module.exports = {
          placeAutocompleteConfig = config['place-autocomplete'] || {},
          params = [],
          exclude = placeAutocompleteConfig.exclude,
+         client = placeAutocompleteConfig.client,
          key = placeAutocompleteConfig.key;
       if (!exclude) {
         if (key)
           params.push('key=' + encodeURIComponent(key));
+        if (client)
+          params.push('client=' + encodeURIComponent(client) + '&v=3.24');
         src += '?' + params.join('&') + "&libraries=places";
         content = '<script type="text/javascript" src="' + src + '"></script>';
       }

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ module.exports = {
       var src = "//maps.googleapis.com/maps/api/js",
          placeAutocompleteConfig = config['place-autocomplete'] || {},
          params = [],
-         include = placesAutocompleteConfig.include,
+         exclude = placesAutocompleteConfig.exclude,
          key = placeAutocompleteConfig.key;
-      if (include) {
+      if (!exclude) {
         if (key)
           params.push('key=' + encodeURIComponent(key));
         src += '?' + params.join('&') + "&libraries=places";

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
       var src = "//maps.googleapis.com/maps/api/js",
          placeAutocompleteConfig = config['place-autocomplete'] || {},
          params = [],
-         exclude = placesAutocompleteConfig.exclude,
+         exclude = placeAutocompleteConfig.exclude,
          key = placeAutocompleteConfig.key;
       if (!exclude) {
         if (key)

--- a/index.js
+++ b/index.js
@@ -9,11 +9,14 @@ module.exports = {
       var src = "//maps.googleapis.com/maps/api/js",
          placeAutocompleteConfig = config['place-autocomplete'] || {},
          params = [],
+         include = placesAutocompleteConfig.include,
          key = placeAutocompleteConfig.key;
-      if (key)
-        params.push('key=' + encodeURIComponent(key));
-      src += '?' + params.join('&') + "&libraries=places";
-      content = '<script type="text/javascript" src="' + src + '"></script>';
+      if (include) {
+        if (key)
+          params.push('key=' + encodeURIComponent(key));
+        src += '?' + params.join('&') + "&libraries=places";
+        content = '<script type="text/javascript" src="' + src + '"></script>';
+      }
     }
     return content;
   }


### PR DESCRIPTION
- Exclude: exclude config parameter allows an add-on consumer to exclude the google maps api from the page. This is helpful in cases where another another ember addon is already providing the library, or the google maps api library is otherwise already included on the page.

- Client: The client config parameter is an alternative to the key parameter for applications that need to provide a [client ID instead of an API key](https://developers.google.com/maps/documentation/javascript/get-api-key#client-id). In this case a stable version number for the Google Maps API must be provided. 