### PR TITLE
Tab index to 0 as default

### DIFF
--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -9,7 +9,7 @@ export default Component.extend({
   inputClass: 'place-autocomplete--input',
   types: 'geocode',
   restrictions: {},
-  tabindex: -1,
+  tabindex: 0,
   withGeoLocate: false,
 
   // @see https://developers.google.com/maps/documentation/javascript/places-autocomplete#set_search_area


### PR DESCRIPTION
I just check this documentation: 

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

I didn't find any reason to set tabindex to -1, so, I am setting it to cero.

