### PR TITLE
Wrap place_changed callback in an Ember run loop

### DIFF
--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -38,7 +38,9 @@ export default Component.extend({
 
   setupComponent() {
     this.getAutocomplete();
-    this.get('autocomplete').addListener('place_changed', this.placeChanged.bind(this));
+    this.get('autocomplete').addListener('place_changed', () => {
+      run(() => { this.placeChanged(); });
+    });
     if (this.get("withGeoLocate")) {
       this.geolocate();
     }


### PR DESCRIPTION
All asynchronous code with side-effects in Ember need to run inside a run-loop. Most async handlers in Ember automatically do this, but when using third party code it's required to manually do this. If you forget, Ember will automatically do this for you, but in test mode (while running tests) this is turned off, and yields and exception.