### PR TITLE
Configurable property used to set value

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In order to use this addon you just have to use the component in your templates.
 
 {{place-autocomplete-field
   value= model.address
-  disable=false
+  disabled=false
   handlerController= this
   inputClass= 'place-autocomplete--input'
   focusOutCallback='done' //Name of the action in the controller

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -63,7 +63,11 @@ export default Component.extend({
       if(document && window){
         let inputElement = document.getElementById(this.elementId).getElementsByTagName('input')[0],
             google = this.get('google') || window.google, //TODO: check how to use the inyected google object
-            autocomplete = new google.maps.places.Autocomplete(inputElement, { types: this._typesToArray(), componentRestrictions: this.get('restrictions') });
+            options = { types: this._typesToArray() };
+        if (Object.keys(this.get('restrictions')).length > 0) {
+          options.componentRestrictions = this.get('restrictions');
+        }
+        let autocomplete = new google.maps.places.Autocomplete(inputElement, options);
         this.set('autocomplete', autocomplete);
       }
     }

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -11,6 +11,8 @@ export default Component.extend({
   restrictions: {},
   tabindex: 0,
   withGeoLocate: false,
+  setValueWithProperty: 'formatted_address',
+
 
   // @see https://developers.google.com/maps/documentation/javascript/places-autocomplete#set_search_area
   geolocate() {
@@ -68,9 +70,9 @@ export default Component.extend({
   },
 
   placeChanged() {
-    let place =  this.get('autocomplete').getPlace();
+    let place = this.get('autocomplete').getPlace();
     this._callCallback('placeChangedCallback', place);
-    this.set('value', place.formatted_address);
+    this.set('value', place[this.get('setValueWithProperty')]);
   },
 
   _callCallback(callback, place) {


### PR DESCRIPTION
Awesome plugin, thanks!

Following changes:
- When no restrictions are set google throws an error (InvalidValueError: setComponentRestrictions: in property country: not a string; and not an Array) in the console, so added check on restrictions object.
- I use the plugin myself with types='establishment' and when user selects a company the value property is set to 'formatted_address' per default. I have made this the default but now configurable via the template tag like: "setValueWithProperty='name'".
- Fixed 'disabled' in README
