### PR TITLE
prevent null/undefined values for latLng/restrictions from erroring out

### DIFF
--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -39,7 +39,7 @@ export default Component.extend({
 
     if (latLngBnds && Object.keys(latLngBnds).length === 2){
       // @see https://developers.google.com/maps/documentation/javascript/places-autocomplete#set_search_area
-      const { sw, ne } = this.get('latLngBounds');
+      const { sw, ne } = latLngBnds;
       options.bounds = new google.maps.LatLngBounds(sw, ne);
     }
 

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -35,14 +35,18 @@ export default Component.extend({
 
     const options = { types: this._typesToArray() };
 
-    if (this.get('latLngBounds')){
+    const latLngBnds = this.get('latLngBounds');
+
+    if (latLngBnds && Object.keys(latLngBnds).length === 2){
       // @see https://developers.google.com/maps/documentation/javascript/places-autocomplete#set_search_area
       const { sw, ne } = this.get('latLngBounds');
       options.bounds = new google.maps.LatLngBounds(sw, ne);
     }
 
-    if (Object.keys(this.get('restrictions')).length > 0) {
-      options.componentRestrictions = this.get('restrictions');
+    const restrictions = this.get('restrictions');
+
+    if (restrictions && Object.keys(restrictions).length > 0) {
+      options.componentRestrictions = restrictions;
     }
 
     return options;


### PR DESCRIPTION
Prevents addon from erroring out if null/undefined value passed for latLngBnds or restrictions