### PR TITLE
Remove types and setValueWithProperty default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In order to use this addon you just have to use the component in your templates.
   types='(cities)' //You don't have to pass this value, default value is 'geocode'
   restrictions= restrictionsObjectFromController // You can pass and object with restriction options.
   withGeoLocate= true // You don't have to pass this value, default value is false
-  setValueWithProperty= 'formatted_address' // Optional, default is formatted_address
+  setValueWithProperty= 'formatted_address' // Optional, defaults to typical Google Autocomplete behavior
   preventSubmit= true // You don't have to pass this value, default value is false. Prevents the form to be submitted if the user hits ENTER
 }}
 

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -1,5 +1,6 @@
 import layout from '../templates/components/place-autocomplete-field';
 import Component from '@ember/component';
+import { isArray } from '@ember/array';
 import { isEmpty, isPresent, typeOf, isEqual, isBlank } from '@ember/utils';
 import { scheduleOnce, run } from "@ember/runloop";
 
@@ -136,9 +137,15 @@ export default Component.extend({
   },
 
   _typesToArray() {
-    if (this.get('types') !== '') {
-      return this.get('types').split(',');
-    } else {
+    let types = this.get('types');
+
+    if (isArray(types)) {
+      return types;
+    }
+    else if (typeOf(types) === 'string') {
+      return types.split(',');
+    }
+    else {
       return [];
     }
   },

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -117,11 +117,9 @@ export default Component.extend({
     let place = this.get('autocomplete').getPlace();
     this._callCallback('placeChangedCallback', place);
 
+    // If setValueWithProperty is undefined, use Google Autocomplete default behavior
     if (place[this.get('setValueWithProperty')] !== undefined) {
       this.set('value', place[this.get('setValueWithProperty')]);
-    } else {
-      // Address not found use value
-      this.set('value', place.name);
     }
   },
 
@@ -150,11 +148,11 @@ export default Component.extend({
       layout: layout,
       disabled: false,
       inputClass: 'place-autocomplete--input',
-      types: 'geocode',
+      types: undefined,
       restrictions: {},
       tabindex: 0,
       withGeoLocate: false,
-      setValueWithProperty: 'formatted_address',
+      setValueWithProperty: undefined,
       preventSubmit: false
     };
 

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -143,7 +143,12 @@ export default Component.extend({
       return types;
     }
     else if (typeOf(types) === 'string') {
-      return types.split(',');
+      if (types.trim() === '') {
+        return [];
+      }
+      else {
+        return types.split(',');
+      }
     }
     else {
       return [];

--- a/tests/integration/components/place-autocomplete-field-test.js
+++ b/tests/integration/components/place-autocomplete-field-test.js
@@ -21,7 +21,7 @@ describe('Integration | Component | Place Autocomplete Field', function() {
     expect(find('input').classList.contains('fake-input-class')).to.equal(true);
   });
 
-  it("accepts 'value' option and updates with google autocomplete response", function() {
+  it("unset 'setValueWithProperty' option does not affect entered address", function() {
     // Mock only google places
     window.google.maps.__gjsload__ = function() {
       return true;
@@ -30,6 +30,18 @@ describe('Integration | Component | Place Autocomplete Field', function() {
     let fakeModel = EmberObject.extend({ address: 'fake address'}).create();
     this.set('fakeModel', fakeModel);
     this.render(hbs`{{place-autocomplete-field value=fakeModel.address}}`);
+    expect(this.get('fakeModel.address')).to.equal('fake address');
+  });
+
+  it("accepts 'value' option and updates with google autocomplete response", function() {
+    // Mock only google places
+    window.google.maps.__gjsload__ = function() {
+      return true;
+    };
+    window.google.maps.places.Autocomplete = GooglePlaceAutocompleteMockedObject;
+    let fakeModel = EmberObject.extend({ address: 'fake address'}).create();
+    this.set('fakeModel', fakeModel);
+    this.render(hbs`{{place-autocomplete-field value=fakeModel.address setValueWithProperty='formatted_address'}}`);
     expect(this.get('fakeModel.address')).to.equal('Cra. 65, Medellín, Antioquia, Colombia');
   });
 

--- a/tests/unit/components/place-autocomplete-field-test.js
+++ b/tests/unit/components/place-autocomplete-field-test.js
@@ -5,6 +5,14 @@ import { setupTest } from 'ember-mocha';
 describe('Integration | Component | PlaceAutocompleteField', function() {
   setupTest('component:place-autocomplete-field');
 
+  it('returns empty array on undefined/null', function(){
+    let component = this.subject();
+    expect(component._typesToArray()).to.eql([]);
+
+    component.set('types', null);
+    expect(component._typesToArray()).to.eql([]);
+  });
+
   it('converts types option to array', function(){
     let component = this.subject();
     component.set('types', 'geocode');
@@ -21,6 +29,12 @@ describe('Integration | Component | PlaceAutocompleteField', function() {
     let component = this.subject();
     component.set('types', '');
     expect(component._typesToArray()).to.eql([]);
+  });
+
+  it('supports array passed as types option', function() {
+    let component = this.subject();
+    component.set('types', ['geocode', 'establishment']);
+    expect(component._typesToArray()).to.eql(['geocode', 'establishment']);
   });
 
   it('get geolocate is not available', function(){


### PR DESCRIPTION
Using no default for these options provides more consistent behavior with the unmodified Google Autocomplete component.