### PR TITLE
enhancement: Remove support for handler controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,11 @@ In order to use this addon you just have to use the component in your templates.
 {{place-autocomplete-field
   value= model.address
   disabled=false
-  handlerController= this
   inputClass= 'place-autocomplete--input'
-  focusOutCallback='done' //Name of the action in the controller
-  placeChangedCallback='placeChanged' //Name of the action in the controller
+  focusOutCallback=(action 'done') //Name of the action to execute
+  placeChangedCallback=(action 'placeChanged') //Name of the action in the controller
   types='(cities)' //You don't have to pass this value, default value is 'geocode'
-  restrictions= restrictionsObjectFromController // You can pass and object with restriction options.
+  restrictions= restrictionsObject // You can pass and object with restriction options.
   withGeoLocate= true // You don't have to pass this value, default value is false
   setValueWithProperty= 'formatted_address' // Optional, defaults to typical Google Autocomplete behavior
   preventSubmit= true // You don't have to pass this value, default value is false. Prevents the form to be submitted if the user hits ENTER
@@ -59,7 +58,6 @@ ENV['place-autocomplete'] = {
 **option**             | **description**
 ---                    | ---                 |
 value                  | Model attribute whe re the address attribute is going to be stored.
-handlerController      | Controller that is going to handle the callbacks functions that could be triggered from the component.
 focusOutCallback       | String : Name of the function that is going to be executed after focus out in the address input
 placeChangedCallback   | String : Name of the function that is going to be executed when address changed
 inputClass             | String : CSS class for the input.

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -128,11 +128,6 @@ export default Component.extend({
     let callbackFn = this.get(callback);
     if (isEqual(typeOf(callbackFn), 'function')) {
       callbackFn(place);
-    } else {
-      let actionName = this.get(callback);
-      if (isPresent(this.get('handlerController')) && isPresent(actionName)) {
-        this.get('handlerController').send(actionName, place);
-      }
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-place-autocomplete",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ember cli addon to provide a component that uses Google Places API to autocomplete place information when someone writes an address in a text field",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,10 +5,9 @@
 <div class="test-place-autocomplete-container" data-google-auto="{{googleAuto}}">
   {{place-autocomplete-field
     value= model.address
-    handlerController= this
     inputClass= 'place-autocomplete--input'
-    focusOutCallback="done"
-    placeChangedCallback="placeChanged"
+    focusOutCallback=(action "done")
+    placeChangedCallback=(action "placeChanged")
     placeholder="Custom placeholder"
     preventSubmit=true
   }}
@@ -21,9 +20,8 @@
 <div class="test-place-autocomplete-container">
   {{place-autocomplete-field
     value= model.address2
-    handlerController=this
     inputClass= 'place-autocomplete--input-2'
-    placeChangedCallback="placeChangedSecondInput"
+    placeChangedCallback=(action "placeChangedSecondInput")
     restrictions=restrictions
     disabled=true
   }}
@@ -38,9 +36,8 @@
 <div class="test-place-autocomplete-container">
   {{place-autocomplete-field
     value= model.address3
-    handlerController=this
     inputClass= 'place-autocomplete--input-3'
-    placeChangedCallback="placeChangedThirdInput"
+    placeChangedCallback=(action "placeChangedThirdInput")
     types=""
     withGeoLocate=true
   }}


### PR DESCRIPTION
## Description

Remove support for `handlerController`, because it goes against Ember principles. This is a breaking change, but it is going to be very beneficial to promote ADDU.