### PR TITLE
Add placeIdOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ placeChangedCallback   | String : Name of the function that is going to be execu
 inputClass             | String : CSS class for the input.
 types                  | String: featured types separate by comma describing the given result, for more info [Available types](https://developers.google.com/places/supported_types#table3)
 restrictions           | Object: ex. `{country: "us"}`, more info [Component Restrictions](https://developers.google.com/maps/documentation/javascript/examples/geocoding-component-restriction)
-placeIdOnly            | Boolean: Optional, defaults to false, only fetches the Place ID when calling the Google Places API
+placeIdOnly            | Boolean: Optional, defaults to false, only fetches the Place ID when calling the Google Places API (more details can be found [here](https://developers.google.com/maps/documentation/javascript/places-autocomplete#get_place_information))
 withGeoLocate          | Boolean: ex. `true`, It allows searching places near by the coordinates given into browser. more info [See attribute options.bounds](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete)
 setValueWithProperty   | String: Name of the property returned by Google to set the input field value after selection. more info about properties available you can find [here](https://developers.google.com/maps/documentation/javascript/3.exp/reference#PlaceResult)
 latLngBounds           | Object: ex. `{sw: {lat: -34, lng: 151}, ne: {lat: -33, lng: 152}}`, It allows searching places near by the given coordinates. more info [See attribute options.bounds](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ placeChangedCallback   | String : Name of the function that is going to be execu
 inputClass             | String : CSS class for the input.
 types                  | String: featured types separate by comma describing the given result, for more info [Available types](https://developers.google.com/places/supported_types#table3)
 restrictions           | Object: ex. `{country: "us"}`, more info [Component Restrictions](https://developers.google.com/maps/documentation/javascript/examples/geocoding-component-restriction)
+placeIdOnly            | Boolean: Optional, defaults to false, only fetches the Place ID when calling the Google Places API
 withGeoLocate          | Boolean: ex. `true`, It allows searching places near by the coordinates given into browser. more info [See attribute options.bounds](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete)
 setValueWithProperty   | String: Name of the property returned by Google to set the input field value after selection. more info about properties available you can find [here](https://developers.google.com/maps/documentation/javascript/3.exp/reference#PlaceResult)
 latLngBounds           | Object: ex. `{sw: {lat: -34, lng: 151}, ne: {lat: -33, lng: 152}}`, It allows searching places near by the given coordinates. more info [See attribute options.bounds](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete)
@@ -77,7 +78,6 @@ preventSubmit          | Boolean: ex. `true`, allows to prevent the form to be s
 ## PlaceChangedCallback
 
 This controller action is going to receive a javascript object with the response from Google Places API ([Response details](https://developers.google.com/places/web-service/details)). You can use the information as you wish.
-
 
 ### Example
 
@@ -133,6 +133,21 @@ This controller action is going to receive a javascript object with the response
   "url": "https://maps.google.com/maps/place?q=Cra.+65,+Medell%C3%ADn,+Antioquia,+Colombia&&ftid=0x8e442902d1edf87f:0x1d183831292a7a27",
   "vicinity": "Medellín",
   "html_attributions": []
+}
+
+```
+
+If `placeIdOnly` is set to true you will only receive the place_id in the response here. This gives you more control on how to retrieve more details about the location. For instance you can use Reverse Geocoding by Place ID (https://developers.google.com/maps/documentation/javascript/examples/geocoding-place-id) which uses the Geocoding API that is approx. 10x cheaper than Places API.
+
+### Example
+
+```js
+{
+  "name": "Carrera 65",
+  "place_id": "ChIJf_jt0QIpRI4RJ3oqKTE4GB0",
+  "types": [
+    "route"
+  ]
 }
 
 ```

--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -36,7 +36,9 @@ export default Component.extend({
    */
   getOptions() {
     const google = this.get('google') || ((window) ? window.google : null);
-    const options = { types: this._typesToArray() };
+    const placeIdOnly = this.get('placeIdOnly') || false;
+
+    const options = { types: this._typesToArray(), placeIdOnly };
 
     const latLngBnds = this.get('latLngBounds');
 


### PR DESCRIPTION
I needed to have more control on what to receive from the Google Places API. I thought this might be worth supporting as an option (like here https://developers.google.com/maps/documentation/javascript/places-autocomplete#get_place_information).

Let's give others the option to either use the default behavior of this addon fetching all the details of a location (which is the default behavior) or restrict it to the Place ID only. Subsequently this also allows others to have more control over the cost factor considering reverse geocoding is 10x cheaper than calling the Places API for all these details.