### PR TITLE
remove places autocomplete containers on willdestroy

### DIFF
--- a/addon/components/place-autocomplete-field.js
+++ b/addon/components/place-autocomplete-field.js
@@ -89,6 +89,9 @@ export default Component.extend({
       let google = this.google || ((window) ? window.google : null);
       if(google && google.maps && google.maps.event) {
         google.maps.event.clearInstanceListeners(this.autocomplete);
+        
+        // remove googles autocomplete drop down containers from the dom
+        this._removePlacesAutoCompleteContainers();
       }
     }
   },
@@ -179,6 +182,13 @@ export default Component.extend({
     let properties = Object.keys(this).filter((prop) => prop.indexOf('data-') >= 0) || [];
     let input = document.getElementById(this.elementId).getElementsByTagName('input')[0];
     properties.forEach((property) => input.setAttribute(property, this.get(property)));
+  },
+
+  _removePlacesAutoCompleteContainers() {
+    const pacContainers = document.querySelectorAll('.pac-container');
+    for (let i = 0; pacContainers.length > i; i++) {
+      pacContainers[i].parentNode.removeChild(pacContainers[i]);
+    }
   },
 
   actions: {

--- a/tests/integration/components/place-autocomplete-field-test.js
+++ b/tests/integration/components/place-autocomplete-field-test.js
@@ -49,6 +49,20 @@ describe('Integration | Component | Place Autocomplete Field', function() {
     expect(this.get('fakeModel.address')).to.equal('Cra. 65, Medellín, Antioquia, Colombia');
   });
 
+  it("removes googles pac-container elements from the dom", async function() {
+    // Mock only google places
+    window.google.maps.__gjsload__ = function() {
+      return true;
+    };
+    window.google.maps.places.Autocomplete = GooglePlaceAutocompleteMockedObject;
+    let fakeModel = EmberObject.extend({ address: 'fake address'}).create();
+    this.set('fakeModel', fakeModel);
+    await render(hbs`{{place-autocomplete-field value=fakeModel.address}}`);
+    const pacContainers = window.document.querySelectorAll('.pac-container');
+    expect(this.get('fakeModel.address')).to.equal('fake address');
+    expect(pacContainers).to.be.empty;
+  });
+
   it('accepts data attributes to input', async function() {
     await render(hbs`{{place-autocomplete-field data-independiente-medellin='what is that'}}`);
     expect(find('input[data-independiente-medellin]')).to.be.ok


### PR DESCRIPTION
On the `willDestroy` hook, this should remove the elements that google leaves in the dom when rendering the auto complete dropdown box.

This would be my first open source contribution, no hard feelings if it's not included :) 
