### PR TITLE
Add the ability to configure which content-for hook the script tag is inject into.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ module.exports = {
 
   contentFor: function(type, config) {
     var content = '';
-    if (type === 'head') {
-      var placeAutocompleteConfig = config['place-autocomplete'] || {},
-         src = placeAutocompleteConfig.src || '//maps.googleapis.com/maps/api/js',
+    var placeAutocompleteConfig = config['place-autocomplete'] || {};
+
+    if (type === (placeAutocompleteConfig.contentForType || 'head')) {
+      var src = placeAutocompleteConfig.src || '//maps.googleapis.com/maps/api/js',
          params = [],
          exclude = placeAutocompleteConfig.exclude,
          client = placeAutocompleteConfig.client,

--- a/tests/dummy/app/templates/configuration.hbs
+++ b/tests/dummy/app/templates/configuration.hbs
@@ -16,7 +16,8 @@
     client: 'gme-myclientid',
     version: 3.27, // Optional - if client is set version must be above 3.24
     language: 'en', // Optional - be default will be based on your browser language
-    region: 'GB' // Optional
+    region: 'GB', // Optional
+    contentForType: 'head' // Optional - Specifies which content-for tag the script will be injected into, defaults to 'head'
   };
 
   ...


### PR DESCRIPTION
Due to a conflict the places library with babel polyfills, I need the ability to load the google maps library later than normal.

I've added the ability to configure which content-for hook the script tag is inject into and updated the documentation.